### PR TITLE
more sleep for esa.io API rate limit (75req/900sec)

### DIFF
--- a/lib/wp2esa.rb
+++ b/lib/wp2esa.rb
@@ -31,7 +31,7 @@ module Wp2esa
         }
         puts params
         client.create_post(params)
-        sleep 0.5
+        sleep 15
       end
     end
   end


### PR DESCRIPTION
esa.io の2017年2月現在のAPI rate limitに合わせてsleepを伸ばします。

https://docs.esa.io/posts/102#2-3-0

> 現時点では、ユーザ毎に15分間に75リクエストまで受け付けます。
> 制限状況はAPIのレスポンスヘッダに含まれる X-RateLimit-* の値をご確認下さい。